### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/zama-msft/745442cd-5b7a-4957-9fa0-6499452d0191/fddbe4ba-2584-4e82-acb0-d20b62d36bf3/_apis/work/boardbadge/a92f3096-7462-448d-8f81-1f3fdb1be939)](https://dev.azure.com/zama-msft/745442cd-5b7a-4957-9fa0-6499452d0191/_boards/board/t/fddbe4ba-2584-4e82-acb0-d20b62d36bf3/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#179](https://dev.azure.com/zama-msft/745442cd-5b7a-4957-9fa0-6499452d0191/_workitems/edit/179). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.